### PR TITLE
Make it easier to add custom pipelines

### DIFF
--- a/examples/custom_pipeline/main.py
+++ b/examples/custom_pipeline/main.py
@@ -1,7 +1,7 @@
 import time
 
 from closedai import ClosedAIPipeline
-from closedai.server import app, data  # noqa
+from closedai.server import app, register_model  # noqa
 
 
 class MyPipeline(ClosedAIPipeline):
@@ -19,5 +19,4 @@ class MyPipeline(ClosedAIPipeline):
             time.sleep(1)
 
 
-pipeline = MyPipeline()
-data["pipeline"] = pipeline
+register_model("my_model", MyPipeline())

--- a/examples/push_to_hub.py
+++ b/examples/push_to_hub.py
@@ -1,3 +1,5 @@
+"""Use this script to push your model pipeline example to the Hugging Face Hub."""
+
 from pathlib import Path
 
 from huggingface_hub import create_repo, upload_folder


### PR DESCRIPTION
Not in love with naming here, but now you can `register_model('some_model', SomePipelineChildClass())` in your custom server to add a model to the server. These are named, so you must specify this name when making requests for completions with the client library.

TODO - see if we should mirror openai api for listing models