### PR TITLE
:sparkles: parametrize model ID for hf pipeline

### DIFF
--- a/src/closedai/__init__.py
+++ b/src/closedai/__init__.py
@@ -5,7 +5,7 @@ import sys
 from typing import TYPE_CHECKING
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4.dev0"
 
 
 _SUBMOD_ATTRS = {

--- a/src/closedai/pipelines/__init__.py
+++ b/src/closedai/pipelines/__init__.py
@@ -18,6 +18,10 @@ if is_transformers_available():
 
 # TODO - load from custom pipeline file
 def get_pipeline(name, **kwargs):
+    if name.startswith("huggingface") and ":" in name:
+        name, repo_id = name.split(":")
+        kwargs["repo_id"] = repo_id
+
     if name in AVAILABLE_PIPELINES:
         return AVAILABLE_PIPELINES[name](**kwargs)
     else:

--- a/src/closedai/pipelines/pipeline_huggingface.py
+++ b/src/closedai/pipelines/pipeline_huggingface.py
@@ -5,7 +5,7 @@ from .pipeline_base import ClosedAIPipeline
 
 
 class HuggingFacePipeline(ClosedAIPipeline):
-    def __init__(self, model=None, tokenizer=None, streamer=None, decode_kwargs=None):
+    def __init__(self, repo_id="gpt2", model=None, tokenizer=None, streamer=None, decode_kwargs=None):
         if is_transformers_available():
             from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer, pipeline
         else:
@@ -13,8 +13,8 @@ class HuggingFacePipeline(ClosedAIPipeline):
                 "HuggingFacePipeline requires transformers to be installed. Please install transformers with `pip install transformers`"
             )
 
-        tokenizer = tokenizer or AutoTokenizer.from_pretrained("gpt2")
-        model = model or AutoModelForCausalLM.from_pretrained("gpt2")
+        tokenizer = tokenizer or AutoTokenizer.from_pretrained(repo_id)
+        model = model or AutoModelForCausalLM.from_pretrained(repo_id)
         self.streamer = streamer or TextIteratorStreamer(tokenizer, skip_prompt=True, **(decode_kwargs or {}))
         self.pipe = pipeline("text-generation", streamer=self.streamer, model=model, tokenizer=tokenizer)
 


### PR DESCRIPTION
Now you can name the model id when starting the server for huggingface.

```
closedai --pipeline_name huggingface:HuggingFaceM4/tiny-random-LlamaForCausalLM
```

then from the client...

```python
from closedai import openai

completion = openai.Completion.create(model='huggingface:HuggingFaceM4/tiny-random-LlamaForCausalLM', prompt='hi there, my name is', stream=False)
```